### PR TITLE
add digital as category

### DIFF
--- a/app/controllers/df/paid_membership/success_recurring_controller.rb
+++ b/app/controllers/df/paid_membership/success_recurring_controller.rb
@@ -55,6 +55,7 @@ http://stackoverflow.com/a/25274645
 				:frequency => invoice.tier_period,
 				# BILLINGPERIOD
 				:period => invoice.paypal_billing_period,
+        :category => :Digital
 		}
     if trialPeriod > 0
       billing_params[:trial] = {


### PR DESCRIPTION
I've added Digital as the category, because PayPal gives a discount for micropayment digital goods.

https://www.paypal.com/us/webapps/mpp/merchant-fees
https://developer.paypal.com/docs/classic/express-checkout/digital-goods/ECDGRecurringPayments/#identifying-items-as-digital-or-physical-goods

![image](https://cloud.githubusercontent.com/assets/5934106/21968803/0b01656a-db56-11e6-844b-1a63f106e487.png)
